### PR TITLE
limit SSH keylength to 2048 for CentOS installs

### DIFF
--- a/bin/arch/centos-sw-probe/centos-sw-probe-ATLAS.sh
+++ b/bin/arch/centos-sw-probe/centos-sw-probe-ATLAS.sh
@@ -63,7 +63,7 @@ ln -sf $RPM_BASE_DIR/state/FIRMWARE_APPS_VERSION $BASE_DIR/state/FIRMWARE_APPS_V
 if [ ! -f "$BASE_DIR"/etc/probe_key ]; then
     name=$(hostname -s)
     mkdir -p "$BASE_DIR"/etc
-    ssh-keygen -t rsa -P '' -C $name -f "$BASE_DIR"/etc/probe_key
+    ssh-keygen -t rsa -b2048 -P '' -C $name -f "$BASE_DIR"/etc/probe_key
     chown -R atlas:atlas "$BASE_DIR"/etc
 fi
 


### PR DESCRIPTION
closes #30, see #28